### PR TITLE
[SP-68] Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
+*.retry
+.ansible/
 settings.yml
-get-pip.py
-requirements.txt
-seedbox.retry


### PR DESCRIPTION
Fix .gitignore so ansible and ansible-lint generated files and folders won't be uploaded on GitHub and remove Cloudbox / Saltbox artefacts.

Exclude the following (ordered alphabetically):
- All retry files (seedbox.retry handled)
- .ansible folder and everything inside
- settings.yml

Removed (not used in our project):
- get-pip.py
- requirements.txt