### PR TITLE
[SP-75] Fix ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 hash_behaviour=merge
+interpreter_python = auto_silent


### PR DESCRIPTION
Add a setting so it stops issuing warning about Python interpreter for every Ansible playbook run.

"[WARNING]: Host 'localhost' is using the discovered Python interpreter at '/usr/bin/python3.13', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.19/reference_appendices/interpreter_discovery.html for more information."