### PR TITLE
[SP-4] & [SP-17] Fix homer-service-discovery & Dashboard Icons and homer linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Only tested with:
 - [filetree](https://github.com/Pro-Tweaker/SEEDbox/blob/main/roles/filetree/tasks/main.yml)
 - [hardening](https://github.com/Pro-Tweaker/SEEDbox/blob/main/roles/hardening/tasks/main.yml)
 - [Homer](https://github.com/bastienwirtz/homer)
-- [Homer Service Discovery](https://github.com/calvinbui/homer-service-discovery)
-- [Dashboard Icons](https://github.com/WalkxCode/dashboard-icons)
+- [Homer Service Discovery](https://github.com/Pro-Tweaker/homer-service-discovery)
+- [Dashboard Icons](https://github.com/homarr-labs/dashboard-icons)
 - [Watchtower](https://github.com/containrrr/watchtower)
 - [postfix](https://github.com/bokysan/docker-postfix)
 ## Download

--- a/roles/homer/tasks/main.yml
+++ b/roles/homer/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 - name: Create directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ user }}"
     group: "{{ group }}"
-    mode: 0775
-    recurse: yes
+    mode: "0775"
+    recurse: true
   loop:
     - "{{ homer.folder }}"
     - "{{ homer.folder }}/discovery"
 
 - name: Create and start Homer container
-  docker_container:
+  community.docker.docker_container:
     name: homer
     image: "b4bz/homer:{{ homer.tag }}"
-    pull: yes
+    pull: true
     recreate: true
     volumes:
       - "{{ homer.folder }}:/www/assets"
@@ -38,17 +38,17 @@
     user: "{{ uid | int }}:{{ gid | int }}"
 
 - name: Homer Settings Tasks
-  include_tasks: "settings/main.yml"
+  ansible.builtin.include_tasks: "settings/main.yml"
 
 - name: Create the management network
-  docker_network:
+  community.docker.docker_network:
     name: management
 
 - name: Create and start Homer Service Discovery container
-  docker_container:
+  community.docker.docker_container:
     name: homer-discovery
-    image: "ghcr.io/calvinbui/homer-service-discovery:{{ homer.tag_companion }}"
-    pull: yes
+    image: "ghcr.io/pro-tweaker/homer-service-discovery:{{ homer.tag_companion }}"
+    pull: true
     recreate: true
     volumes:
       - "{{ homer.folder }}/config.yml:/config.yml"

--- a/roles/homer/tasks/settings/main.yml
+++ b/roles/homer/tasks/settings/main.yml
@@ -1,34 +1,35 @@
 - name: Settings | Wait for 'config.yml' to be created
-  wait_for:
+  ansible.builtin.wait_for:
     path: "{{ homer.folder }}/config.yml"
     state: present
 
 - name: Settings | Wait for 10 seconds before stopping homer container
-  wait_for:
+  ansible.builtin.wait_for:
     timeout: 10
 
 - name: Settings | Stop container
-  docker_container:
+  community.docker.docker_container:
     name: homer
     state: stopped
 
 - name: Settings | GIT Clone/Pull Icons Repository
-  git:
-    repo: https://github.com/WalkxCode/dashboard-icons.git
+  ansible.builtin.git:
+    repo: https://github.com/homarr-labs/dashboard-icons.git
+    version: main
     dest: "{{ homer.folder }}/homer-icons"
-    update: yes
-    force: yes
+    update: true
+    force: true
 
 - name: Settings | Import custom 'base.yml'
-  template:
+  ansible.builtin.template:
     src: config.yml.j2
     dest: "{{ homer.folder }}/discovery/base.yml"
-    force: yes
+    force: true
     owner: "{{ user }}"
     group: "{{ group }}"
-    mode: 0775
+    mode: "0775"
 
 - name: Settings | Start container
-  docker_container:
+  community.docker.docker_container:
     name: homer
     state: started


### PR DESCRIPTION
[SP-4] Fix homer-service-discover:
- Switch from [calvinbui/homer-service-discovery](https://github.com/calvinbui/homer-service-discovery) (archived) to our own fork [Pro-Tweaker/homer-service-discovery](https://github.com/Pro-Tweaker/homer-service-discovery)

[SP-17] Fix Dashboard Icons :
- Update links [WalkxCode/dashboard-icons](https://github.com/WalkxCode/dashboard-icons) to [homarr-labs/dashboard-icons](https://github.com/homarr-labs/dashboard-icons)

Linting via yamllint and ansible-lint (production)