### PR TITLE
[SP-24] Block automatic updates of torrent clients

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -142,7 +142,7 @@ librespeed:
   folder: /opt/librespeed
   subdomain: librespeed
 qbittorrent:
-  tag: latest
+  tag: "5.1.4"
   folder: /opt/qbittorrent
   subdomain: qbittorrent
   web_user: admin_qbit


### PR DESCRIPTION
For private trackers, it's not a good idea to automatically push latest versions as it always take days/weeks before it's whitelisted everywhere.