### PR TITLE
[SP-64] Add Crowdsec and Cloudflare dashboard link on Homer

### DIFF
--- a/roles/cloudflare/tasks/ddns/main.yml
+++ b/roles/cloudflare/tasks/ddns/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Create and start Cloudflare Dynamic DNS Updater
-  docker_container:
+  community.docker.docker_containe:
     name: cf-ddns
     image: "oznu/cloudflare-ddns:{{ cloudflare.tag_ddns }}"
-    pull: yes
+    pull: true
     recreate: true
     state: started
     restart_policy: always

--- a/roles/cloudflare/tasks/ddns/main.yml
+++ b/roles/cloudflare/tasks/ddns/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create and start Cloudflare Dynamic DNS Updater
-  community.docker.docker_containe:
+  community.docker.docker_container:
     name: cf-ddns
     image: "oznu/cloudflare-ddns:{{ cloudflare.tag_ddns }}"
     pull: true

--- a/roles/cloudflare/tasks/main.yml
+++ b/roles/cloudflare/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Cloudflare | Dynamic DNS Updater
-  include_tasks: "ddns/main.yml"
+  ansible.builtin.include_tasks: "ddns/main.yml"
   when: dynamic_ip | bool
 
 - name: Cloudflare | Traefik Companion
-  include_tasks: "traefik/main.yml"
+  ansible.builtin.include_tasks: "traefik/main.yml"

--- a/roles/cloudflare/tasks/traefik/main.yml
+++ b/roles/cloudflare/tasks/traefik/main.yml
@@ -1,14 +1,24 @@
 ---
 - name: Create and start Traefik Cloudflare Companion
-  docker_container:
+  community.docker.docker_container:
     name: cf-companion
     image: "tiredofit/traefik-cloudflare-companion:{{ cloudflare.tag_companion }}"
-    pull: yes
+    pull: true
     recreate: true
     state: started
     restart_policy: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      # Homer
+      homer.enable: "true"
+      homer.name: "Cloudflare"
+      homer.service: "Management"
+      homer.priority: "600"
+      homer.subtitle: "DNS, CDN and DDoS mitigation services"
+      homer.url: "https://dash.cloudflare.com/"
+      homer.logo: "assets/homer-icons/svg/cloudflare.svg"
+      homer.target: "_blank"
     env:
       TRAEFIK_VERSION: "2"
       CF_TOKEN: "{{ cloudflare.api_key }}"

--- a/roles/crowdsec/tasks/main.yml
+++ b/roles/crowdsec/tasks/main.yml
@@ -46,6 +46,15 @@
     restart_policy: unless-stopped
     state: started
     labels:
+      # Homer
+      homer.enable: "true"
+      homer.name: "CrowdSec"
+      homer.service: "Management"
+      homer.priority: "500"
+      homer.subtitle: "Curated Threat Intelligence Powered by the Crowd"
+      homer.url: "https://app.crowdsec.net/"
+      homer.logo: "assets/homer-icons/svg/crowdsec.svg"
+      homer.target: "_blank"
     env:
       GID: "{{ gid }}"
       COLLECTIONS: "crowdsecurity/linux


### PR DESCRIPTION
This PR:

- Add CrowdSec dashboard shortcut in Homer
- Add Cloudflare dashboard shortcut in Homer
- Linting of the two roles