### PR TITLE
[SP-98] Fix community.general.xml dependency

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - community.docker
+  - community.general


### PR DESCRIPTION
This PR might fix issues with community.general.xml as used in some of the ansible roles.

```
[WARNING]: Error loading plugin 'community.general.xml': No module named 'ansible_collections.community.general'
[ERROR]: couldn't resolve module/action 'community.general.xml'. This often indicates a misspelling, missing collection, or incorrect module path.
```

https://docs.ansible.com/projects/ansible/latest/collections/community/general/xml_module.html
https://galaxy.ansible.com/ui/repo/published/community/general/

ansible-galaxy collection list
sudo ansible-galaxy collection list