### PR TITLE
[SP-99] Fix lookup ansible.builtin.template for pvr roles

### DIFF
--- a/roles/lidarr/tasks/settings/main.yml
+++ b/roles/lidarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/lidarr/tasks/settings/main.yml
+++ b/roles/lidarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/radarr/tasks/settings/main.yml
+++ b/roles/radarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/radarr/tasks/settings/main.yml
+++ b/roles/radarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/readarr/tasks/settings/main.yml
+++ b/roles/readarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/readarr/tasks/settings/main.yml
+++ b/roles/readarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/sonarr/tasks/settings/main.yml
+++ b/roles/sonarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('template', 'post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"

--- a/roles/sonarr/tasks/settings/main.yml
+++ b/roles/sonarr/tasks/settings/main.yml
@@ -28,7 +28,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_rootfolder_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_rootfolder_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"
@@ -40,7 +40,7 @@
     status_code:
       - 201
       - 400
-    body: "{{ lookup('ansible.builtin.template', '../../templates/post_downloadclient_body.json.j2') }}"
+    body: "{{ lookup('ansible.builtin.template', role_path + '/templates/post_downloadclient_body.json.j2') }}"
     body_format: json
     headers:
       X-Api-Key: "{{ api_info.matches[0].ApiKey }}"


### PR DESCRIPTION
This PR attempts to fix this error that happens when linting or running 4x PVR roles:

`WARNING  /usr/lib/python3/dist-packages/ansible/plugins/lookup/__init__.py:138 AnsibleWarning Unable to find '../templates/post_rootfolder_body.json.j2' in expected paths (use -vvvvv to see paths)
WARNING  /usr/lib/python3/dist-packages/ansible/plugins/lookup/__init__.py:138 AnsibleWarning Unable to find '../templates/post_downloadclient_body.json.j2' in expected paths (use -vvvvv to see paths)`

https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/uri_module.html
https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_lookups.html