### PR TITLE
[SP-100] Fix homer init flag

### DIFF
--- a/roles/homer/tasks/main.yml
+++ b/roles/homer/tasks/main.yml
@@ -33,7 +33,7 @@
       traefik.http.services.homer.loadbalancer.server.port: "8080"
       traefik.http.routers.homer.middlewares: "authelia-basic@docker"
     env:
-      INIT_ASSETS: "0"
+      INIT_ASSETS: "1"
       TZ: "{{ tz }}"
     user: "{{ uid | int }}:{{ gid | int }}"
 


### PR DESCRIPTION
This PR should fix Homer role (first run)

https://github.com/bastienwirtz/homer/issues/441#issuecomment-1114207824

`Environment variables:`
`INIT_ASSETS (default: 1) Install example configuration file & assets (favicons, ...) to help you get started.`
