### PR TITLE
[SP-111] Upgrade qBittorrent to v5.2.3

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -94,7 +94,7 @@ postfix:
 
 # Download
 qbittorrent:
-  tag: 5.1.4
+  tag: 5.2.3
   folder: /opt/qbittorrent
   subdomain: qbittorrent
   web_user: admin_qbit


### PR DESCRIPTION
This PR upgrade qBittorrent to v5.2.3

https://github.com/qbittorrent/qBittorrent/releases/tag/release-5.2.3