### PR TITLE
[SP-2] Migrate speedtest-tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ ansible-playbook seedbox.yml --tags=qbittorrent,jellyfin
 
 #### Tag: "Monitoring"
 - [Netdata](https://www.netdata.cloud/)
-- [Speedtest Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker)
+- [Speedtest Tracker](https://speedtest-tracker.dev/)
 - [LibreSpeed](https://librespeed.org/)
 - [Scrutiny](https://github.com/AnalogJ/scrutiny)
 

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -206,6 +206,9 @@ speedtesttracker:
   tag: latest
   folder: /opt/speedtesttracker
   subdomain: speedtesttracker
+  app_key:
+  admin_email:
+  admin_password:
 librespeed:
   tag: latest
   folder: /opt/librespeed

--- a/roles/speedtesttracker/tasks/main.yml
+++ b/roles/speedtesttracker/tasks/main.yml
@@ -10,10 +10,27 @@
   loop:
     - "{{ speedtesttracker.folder }}"
 
+- name: Generate persistent APP_KEY if not provided
+  ansible.builtin.set_fact:
+    speedtesttracker_app_key: >-
+      {{ speedtesttracker.app_key if speedtesttracker.app_key else
+         'base64:' ~ (lookup('ansible.builtin.password', speedtesttracker.folder + '/.secrets/app_key',
+                              length=32, chars=['ascii_letters', 'digits']) | b64encode) }}
+  no_log: true
+
+- name: Generate persistent admin credentials if not provided
+  ansible.builtin.set_fact:
+    speedtesttracker_admin_email: "{{ speedtesttracker.admin_email if speedtesttracker.admin_email else 'admin@' ~ domain }}"
+    speedtesttracker_admin_password: >-
+      {{ speedtesttracker.admin_password if speedtesttracker.admin_password else
+         lookup('ansible.builtin.password', speedtesttracker.folder + '/.secrets/admin_password',
+                length=24, chars=['ascii_letters', 'digits']) }}
+  no_log: true
+
 - name: Create and start container
   community.docker.docker_container:
     name: speedtesttracker
-    image: "henrywhitaker3/speedtest-tracker:{{ speedtesttracker.tag }}"
+    image: "ghcr.io/linuxserver/speedtest-tracker:{{ speedtesttracker.tag }}"
     pull: true
     recreate: true
     volumes:
@@ -45,4 +62,13 @@
       TZ: "{{ tz | string }}"
       PGID: "{{ gid | string }}"
       PUID: "{{ uid | string }}"
-      OOKLA_EULA_GDPR: "true"
+      APP_KEY: "{{ speedtesttracker_app_key }}"
+      APP_URL: "https://{{ speedtesttracker.subdomain }}.{{ domain }}"
+      DB_CONNECTION: "sqlite"
+      ADMIN_NAME: "Admin"
+      ADMIN_EMAIL: "{{ speedtesttracker_admin_email }}"
+      ADMIN_PASSWORD: "{{ speedtesttracker_admin_password }}"
+
+- name: Show Speedtest Tracker admin credentials
+  ansible.builtin.debug:
+    msg: "Speedtest Tracker admin login -> email: {{ speedtesttracker_admin_email }}, password: {{ speedtesttracker_admin_password }}"


### PR DESCRIPTION
This PR migrates speedtest-tracker from henrywhitaker3/Speedtest-Tracker to https://github.com/alexjustesen/speedtest-tracker

Website (and doc): https://speedtest-tracker.dev/
https://docs.speedtest-tracker.dev/getting-started/installation/using-docker-compose
https://docs.speedtest-tracker.dev/getting-started/environment-variables

Image is officially provided by linuxserver:

https://docs.linuxserver.io/images/docker-speedtest-tracker/
https://github.com/linuxserver/docker-speedtest-tracker
https://hub.docker.com/r/linuxserver/speedtest-tracker

- Migrated to linuxserver/speedtest-tracker
- Added all the required defaults variables in the role and default settings file
- Required: APP_KEY can be gen with : echo "base64:$(openssl rand -base64 32 2>/dev/null)" for database encryption
- Required: ADMIN_NAME and ADMIN_EMAIL and ADMIN_PASSWORD for login on the webui
- Credentials values are persistent and generated by Ansible if none are provided by the custom settings.yml file
- Values are outputted on each role run and if already existed are cat from secret file location, so for each run, credentials will persist unless the opt folder is deleted, new values will be generated and used.