### PR TITLE
[SP-115] Modify homer matrix order

### DIFF
--- a/roles/archivebox/tasks/main.yml
+++ b/roles/archivebox/tasks/main.yml
@@ -39,7 +39,7 @@
       homer.enable: "true"
       homer.name: "ArchiveBox"
       homer.service: "Tools"
-      homer.priority: "1"
+      homer.priority: "100"
       homer.subtitle: "Open-source self-hosted web archiving"
       homer.url: "https://{{ archivebox.subdomain }}.{{ domain }}"
       homer.logo: "assets/homer-icons/svg/archivebox.svg"

--- a/roles/bazarr/tasks/main.yml
+++ b/roles/bazarr/tasks/main.yml
@@ -37,7 +37,7 @@
       homer.enable: "true"
       homer.name: "Bazarr"
       homer.service: "Tools"
-      homer.priority: "300"
+      homer.priority: "400"
       homer.subtitle: "Manage and download subtitles"
       homer.url: "https://{{ bazarr.subdomain }}.{{ domain }}"
       homer.logo: "assets/homer-icons/svg/bazarr.svg"

--- a/roles/filebrowser/tasks/main.yml
+++ b/roles/filebrowser/tasks/main.yml
@@ -68,7 +68,7 @@
       homer.enable: "true"
       homer.name: "Filebrowser"
       homer.service: "Tools"
-      homer.priority: "500"
+      homer.priority: "300"
       homer.subtitle: "Web File Browser"
       homer.url: "https://{{ filebrowser.subdomain }}.{{ domain }}"
       homer.logo: "assets/homer-icons/svg/filebrowser.svg"

--- a/roles/prowlarr/tasks/main.yml
+++ b/roles/prowlarr/tasks/main.yml
@@ -36,7 +36,7 @@
       homer.enable: "true"
       homer.name: "Prowlarr"
       homer.service: "Tools"
-      homer.priority: "400"
+      homer.priority: "500"
       homer.subtitle: "Indexer manager/proxy"
       homer.url: "https://{{ prowlarr.subdomain }}.{{ domain }}"
       homer.logo: "assets/homer-icons/svg/prowlarr.svg"


### PR DESCRIPTION
This PR changes the order of the apps in the "Tools" category in Homer.

I think this order makes more sense.

From:

Tools - Filebrowser 500
Tools - Prowlarr 400
Tools - Bazarr 300
Tools - Syncthing 200
Tools - ArchiveBox 1

To:

Tools - Prowlarr 500
Tools - Bazarr 400
Tools - Filebrowser 300
Tools - Syncthing 200
Tools - ArchiveBox 100