### PR TITLE
[SP-116] Add scheduled tests for Speedtest Tracker

### DIFF
--- a/roles/speedtesttracker/tasks/main.yml
+++ b/roles/speedtesttracker/tasks/main.yml
@@ -68,6 +68,7 @@
       ADMIN_NAME: "Admin"
       ADMIN_EMAIL: "{{ speedtesttracker_admin_email }}"
       ADMIN_PASSWORD: "{{ speedtesttracker_admin_password }}"
+      SPEEDTEST_SCHEDULE: "0 */4 * * *" # Run speedtest every 4 hours
 
 - name: Show Speedtest Tracker admin credentials
   ansible.builtin.debug:


### PR DESCRIPTION
This PR set a speedtest schedule (to every 4 hours) as by default it's only manual runs.

https://docs.speedtest-tracker.dev/getting-started/environment-variables#speed-tests

as nothing is set by default.

-> “At minute 0 past every 4th hour.”
0 */4 * * *